### PR TITLE
Raise exception for syscall errors

### DIFF
--- a/ext/fcgi/fcgi.c
+++ b/ext/fcgi/fcgi.c
@@ -186,8 +186,7 @@ static VALUE fcgi_finish(VALUE self)
 	extern int errno; \
   if (err) {\
     if (err > 0) {\
-			errno = err;\
-      rb_sys_fail(NULL);\
+      rb_raise(eFCGIStreamError, "unknown error (syscall error)");\
     }\
     else {\
       switch (err) {\


### PR DESCRIPTION
rb_sys_fail can't be catched in ruby, but there is no reason to terminate the process (especially not on EPIPE)
