### PR TITLE
Migrate from select to rb_thread_fd_select

### DIFF
--- a/TODO
+++ b/TODO
@@ -1,4 +1,0 @@
-* move from select() to rb_thread_fd_select(),
-	since rb_thread_select() is deprecated
-	(and I have no time to do that now, unfortunately)
-	any help is welcomed.

--- a/ext/fcgi/fcgi.c
+++ b/ext/fcgi/fcgi.c
@@ -78,7 +78,7 @@ static VALUE fcgi_s_accept(VALUE self)
 {
   int status;
   FCGX_Request *req;
-  fd_set readfds;
+  rb_fdset_t readfds;
 
   req = ALLOC(FCGX_Request);
 
@@ -88,9 +88,9 @@ static VALUE fcgi_s_accept(VALUE self)
     return Qnil;
   }
 
-  FD_ZERO(&readfds);
-  FD_SET(req->listen_sock, &readfds);
-  if (select(req->listen_sock+1, &readfds, NULL, NULL, NULL) < 1) {
+  rb_fd_init(&readfds);
+  rb_fd_set(req->listen_sock, &readfds);
+  if (rb_thread_fd_select(readfds.maxfd, &readfds, NULL, NULL, NULL) < 1) {
     return Qnil;
   }
 


### PR DESCRIPTION
This patch seems to work fine and restores the old behavior: the threads aren't blocked anymore.
