### PR TITLE
Support for environment without `libfcgi`

### DIFF
--- a/ext/fcgi/Makefile
+++ b/ext/fcgi/Makefile
@@ -1,1 +1,0 @@
-# Use ruby extconf.rb to generate makefile

--- a/ext/fcgi/extconf.rb
+++ b/ext/fcgi/extconf.rb
@@ -4,4 +4,6 @@ dir_config("fcgi")
 
 if (have_header("fcgiapp.h") || have_header("fastcgi/fcgiapp.h")) && have_library("fcgi", "FCGX_Accept")
   create_makefile("fcgi")
+else
+  File.write("Makefile", dummy_makefile($srcdir).join(""))
 end

--- a/fcgi.gemspec
+++ b/fcgi.gemspec
@@ -17,7 +17,6 @@ Gem::Specification.new do |s|
   s.files = [
     "VERSION",
     "ext/fcgi/MANIFEST",
-    "ext/fcgi/Makefile",
     "ext/fcgi/extconf.rb",
     "ext/fcgi/fcgi.c",
     "lib/fcgi.rb",


### PR DESCRIPTION
Error when installing in an environment without `libfcgi`.

```
Building native extensions. This could take a while...
ERROR:  Error installing ./fcgi-0.9.2.2.gem:
	ERROR: Failed to build gem native extension.

    current directory: /usr/local/bundle/gems/fcgi-0.9.2.2/ext/fcgi
/usr/local/bin/ruby -I /usr/local/lib/ruby/3.1.0 extconf.rb
checking for fcgiapp.h... no
checking for fastcgi/fcgiapp.h... no

current directory: /usr/local/bundle/gems/fcgi-0.9.2.2/ext/fcgi
make DESTDIR\= sitearchdir\=./.gem.20240227-8-iazipy sitelibdir\=./.gem.20240227-8-iazipy clean
make: *** No rule to make target 'clean'.  Stop.

current directory: /usr/local/bundle/gems/fcgi-0.9.2.2/ext/fcgi
make DESTDIR\= sitearchdir\=./.gem.20240227-8-iazipy sitelibdir\=./.gem.20240227-8-iazipy
make: *** No targets.  Stop.

make failed, exit code 2

Gem files will remain installed in /usr/local/bundle/gems/fcgi-0.9.2.2 for inspection.
Results logged to /usr/local/bundle/extensions/x86_64-linux/3.1.0/fcgi-0.9.2.2/gem_make.out
```

However, there is also a Pure Ruby implementation that works without `libfcgi`.
With this change, the installation will succeed even without `libfcgi`.